### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.6](https://github.com/0xCCF4/PhotoSort/compare/v0.1.5...v0.1.6) - 2024-06-26
+
+### Added
+- updated ci, added release plz, devskim, automerge dependabot
+
+### Fixed
+- ci auto merge pr
+- fixing ci video lib missing
+- fixing ci video lib missing
+- change ci token
+- change ci token
+- change compile against stable in ci
+
+### Other
+- *(deps)* bump rust-build/rust-build.action from 1.4.4 to 1.4.5 ([#13](https://github.com/0xCCF4/PhotoSort/pull/13))
+- renamed ci jobs
+- Bump clap from 4.5.4 to 4.5.7 ([#10](https://github.com/0xCCF4/PhotoSort/pull/10))
+- Bump regex from 1.10.4 to 1.10.5 ([#9](https://github.com/0xCCF4/PhotoSort/pull/9))
+- Bump lazy_static from 1.4.0 to 1.5.0 ([#11](https://github.com/0xCCF4/PhotoSort/pull/11))
+- cargo fmt and clippy
+- update ci
+- update ci
+- Merge pull request [#6](https://github.com/0xCCF4/PhotoSort/pull/6) from 0xCCF4/dependabot/cargo/anyhow-1.0.86
+- Bump ffmpeg-next from 7.0.0 to 7.0.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "photo_sort"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "photo_sort"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = """
 A tool to rename and sort photos/videos by its EXIF date/metadata. It tries to extract the date


### PR DESCRIPTION
## 🤖 New release
* `photo_sort`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/0xCCF4/PhotoSort/compare/v0.1.5...v0.1.6) - 2024-06-26

### Added
- updated ci, added release plz, devskim, automerge dependabot

### Fixed
- ci auto merge pr
- fixing ci video lib missing
- fixing ci video lib missing
- change ci token
- change ci token
- change compile against stable in ci

### Other
- *(deps)* bump rust-build/rust-build.action from 1.4.4 to 1.4.5 ([#13](https://github.com/0xCCF4/PhotoSort/pull/13))
- renamed ci jobs
- Bump clap from 4.5.4 to 4.5.7 ([#10](https://github.com/0xCCF4/PhotoSort/pull/10))
- Bump regex from 1.10.4 to 1.10.5 ([#9](https://github.com/0xCCF4/PhotoSort/pull/9))
- Bump lazy_static from 1.4.0 to 1.5.0 ([#11](https://github.com/0xCCF4/PhotoSort/pull/11))
- cargo fmt and clippy
- update ci
- update ci
- Merge pull request [#6](https://github.com/0xCCF4/PhotoSort/pull/6) from 0xCCF4/dependabot/cargo/anyhow-1.0.86
- Bump ffmpeg-next from 7.0.0 to 7.0.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).