### PR TITLE
feat!: choose a folder schema to move files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
-# Default owner
-* @0xCCF4
-
 # Github workflows
 /.github/ @0xCCF4

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -36,5 +36,5 @@ jobs:
 
       - uses: actions/attest-build-provenance@v1
         with:
-          subject-path: ${{ github.workspace }}/target/release/backup-deduplicator
+          subject-path: ${{ github.workspace }}/target/release/photo_sort
         continue-on-error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,6 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 name = "photo_sort"
 version = "0.1.6"
 dependencies = [
- "aho-corasick",
  "anyhow",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ kamadak-exif = "0.5.5"
 clap = { version = "4.5.17", features = ["derive"] }
 regex = "1.10.6"
 lazy_static = "1.5.0"
-aho-corasick = "1.1.2"
 env_logger = "0.11.5"
 log = "0.4.22"
 filetime = "0.2.25"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ This command will sort the photos in the `/path/to/photos` directory, rename the
 then move
 them to the `/path/to/sorted_photos` directory.
 
+> You are not sure what the tool will do? Run it with the `--dry-run` flag to see what it would do without actually
+> changing anything.
+
 Another example:
 
 ```bash
@@ -124,6 +127,15 @@ cargo install --features video --path .
 
 Contributions to PhotoSort are welcome! If you have a feature request, bug report, or want to contribute to the code,
 please open an issue or a pull request.
+
+### Something works differently than expected?
+
+Try running the tool with the `RUST_LOG` environment variable set to `trace` to get more information about what the tool
+is doing and open an issue with the output.
+    
+```bash
+RUST_LOG=trace photo_sort --source_dir /path/to/photos --target_dir /path/to/sorted_photos
+```
 
 ## License
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -1,10 +1,11 @@
 use filetime::FileTime;
 use log::{debug, error, warn};
+use std::fmt::{Display, Formatter};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-/// `ActionMode` is an enumeration that defines the different types of actions that can be performed on a file.
+/// `ActualAction` is an enumeration that defines the different types of actions that can be performed on a file.
 ///
 /// # Variants
 ///
@@ -13,41 +14,62 @@ use std::str::FromStr;
 /// * `Hardlink` - Represents the action of creating a hard link to a file.
 /// * `RelativeSymlink` - Represents the action of creating a relative symbolic link to a file.
 /// * `AbsoluteSymlink` - Represents the action of creating an absolute symbolic link to a file.
-/// * `DryRun` - Represents a dry run action, which prints the operation that would be performed without actually performing it.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum ActionMode {
+pub enum ActualAction {
     Move,
     Copy,
     Hardlink,
     RelativeSymlink,
     AbsoluteSymlink,
-    DryRun,
 }
 
-/// `FromStr` trait implementation for `ActionMode`.
+impl Display for ActualAction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ActualAction::Move => write!(f, "Move"),
+            ActualAction::Copy => write!(f, "Copy"),
+            ActualAction::Hardlink => write!(f, "Hardlink"),
+            ActualAction::RelativeSymlink => write!(f, "RelSymlink"),
+            ActualAction::AbsoluteSymlink => write!(f, "AbsSymlink"),
+        }
+    }
+}
+
+/// `ActionMode` defines the mode of operation of the tool
 ///
-/// This allows a string to be parsed into the `ActionMode` enum.
+/// # Variants
+/// * `Execute` - The provided action will be executed
+/// * `DryRun` - The provided action will be printed but not executed
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ActionMode {
+    Execute(ActualAction),
+    DryRun(ActualAction),
+}
+
+/// `FromStr` trait implementation for `ActualAction`.
+///
+/// This allows a string to be parsed into the `ActualAction` enum.
 ///
 /// # Arguments
 ///
-/// * `s` - A string slice that should be parsed into an `ActionMode`.
+/// * `s` - A string slice that should be parsed into an `ActualAction`.
 ///
 /// # Returns
 ///
-/// * `Result<Self, Self::Err>` - Returns `Ok(ActionMode)` if the string could be parsed into an `ActionMode`, `Err(anyhow::Error)` otherwise.
-impl FromStr for ActionMode {
+/// * `Result<Self, Self::Err>` - Returns `Ok(ActualAction)` if the string could be parsed into an `ActionMode`, `Err(anyhow::Error)` otherwise.
+impl FromStr for ActualAction {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> anyhow::Result<Self> {
         match s.to_lowercase().as_str() {
-            "move" => Ok(ActionMode::Move),
-            "copy" => Ok(ActionMode::Copy),
-            "hardlink" => Ok(ActionMode::Hardlink),
-            "hard" => Ok(ActionMode::Hardlink), // Alias for "Hardlink"
-            "relative_symlink" => Ok(ActionMode::RelativeSymlink),
-            "relsym" => Ok(ActionMode::RelativeSymlink), // Alias for "RelativeSymlink"
-            "absolute_symlink" => Ok(ActionMode::AbsoluteSymlink),
-            "abssym" => Ok(ActionMode::AbsoluteSymlink), // Alias for "AbsoluteSymlink"
+            "move" => Ok(ActualAction::Move),
+            "copy" => Ok(ActualAction::Copy),
+            "hardlink" => Ok(ActualAction::Hardlink),
+            "hard" => Ok(ActualAction::Hardlink), // Alias for "Hardlink"
+            "relative_symlink" => Ok(ActualAction::RelativeSymlink),
+            "relsym" => Ok(ActualAction::RelativeSymlink), // Alias for "RelativeSymlink"
+            "absolute_symlink" => Ok(ActualAction::AbsoluteSymlink),
+            "abssym" => Ok(ActualAction::AbsoluteSymlink), // Alias for "AbsoluteSymlink"
             _ => Err(anyhow::anyhow!("Invalid action mode")),
         }
     }
@@ -67,12 +89,13 @@ impl FromStr for ActionMode {
 ///
 /// # Actions
 ///
-/// * `ActionMode::Move` - Moves the source file to the target location.
-/// * `ActionMode::Copy` - Copies the source file to the target location.
-/// * `ActionMode::Hardlink` - Creates a hard link at the target location pointing to the source file.
-/// * `ActionMode::RelativeSymlink` - Creates a relative symbolic link at the target location pointing to the source file.
-/// * `ActionMode::AbsoluteSymlink` - Creates an absolute symbolic link at the target location pointing to the source file.
 /// * `ActionMode::DryRun` - Prints the operation that would be performed without actually performing it.
+/// * `ActionMode::Execute` - Performs the specified action on the source file and target file.
+///    * `ActualAction::Move` - Moves the source file to the target location.
+///    * `ActualAction::Copy` - Copies the source file to the target location.
+///    * `ActualAction::Hardlink` - Creates a hard link at the target location pointing to the source file.
+///    * `ActualAction::RelativeSymlink` - Creates a relative symbolic link at the target location pointing to the source file.
+///    * `ActualAction::AbsoluteSymlink` - Creates an absolute symbolic link at the target location pointing to the source file.
 ///
 /// # Errors
 ///
@@ -83,17 +106,17 @@ impl FromStr for ActionMode {
 pub fn file_action(source: &PathBuf, target: &PathBuf, action: &ActionMode) -> std::io::Result<()> {
     error_file_exists(target)?;
     match action {
-        ActionMode::Move => move_file(source, target),
-        ActionMode::Copy => copy_file(source, target),
-        ActionMode::Hardlink => hardlink_file(source, target),
-        ActionMode::RelativeSymlink => relative_symlink_file(source, target),
-        ActionMode::AbsoluteSymlink => absolute_symlink_file(source, target),
-        ActionMode::DryRun => dry_run(source, target),
+        ActionMode::Execute(ActualAction::Move) => move_file(source, target),
+        ActionMode::Execute(ActualAction::Copy) => copy_file(source, target),
+        ActionMode::Execute(ActualAction::Hardlink) => hardlink_file(source, target),
+        ActionMode::Execute(ActualAction::RelativeSymlink) => relative_symlink_file(source, target),
+        ActionMode::Execute(ActualAction::AbsoluteSymlink) => absolute_symlink_file(source, target),
+        ActionMode::DryRun(action) => dry_run(source, target, action),
     }
 }
 
-fn dry_run(source: &PathBuf, target: &PathBuf) -> std::io::Result<()> {
-    println!("{:?} -> {:?}", source, target);
+fn dry_run(source: &PathBuf, target: &PathBuf, action: &ActualAction) -> std::io::Result<()> {
+    println!("[{}] {:?} -> {:?}", action, source, target);
     Ok(())
 }
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,5 +1,6 @@
 pub mod exif2date;
 pub mod filename2date;
+pub mod name_formatters;
 #[cfg(feature = "video")]
 pub mod video2date;
 

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -1,190 +1,14 @@
-use anyhow::anyhow;
+pub mod exif2date;
+pub mod filename2date;
+#[cfg(feature = "video")]
+pub mod video2date;
+
 use anyhow::Result;
-use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
-use exif;
-#[cfg(feature = "video")]
-use ffmpeg_next as ffmpeg;
-use regex;
-use std::fs::File;
-#[cfg(feature = "video")]
-use std::path::Path;
-#[cfg(feature = "video")]
-use std::sync::Mutex;
+use chrono::NaiveDateTime;
 
-/// This function retrieves the date and time from the EXIF data of a file.
-///
-/// # Arguments
-///
-/// * `file` - A reference to a `File` object.
-///
-/// # Returns
-///
-/// * `Result<Option<NaiveDateTime>>` - A `Result` that, if `Ok`, contains an `Option` with the date and time from the EXIF data.
-///   If the date and time could not be retrieved, the `Option` will be `None`.
-///   If an error occurred during the process, the `Result` will be `Err`.
-///
-/// # Errors
-///
-/// This function will return an error if:
-///
-/// * The file could not be read.
-/// * The EXIF data could not be read from the file.
-/// * The date and time could not be parsed from the EXIF data.
-pub fn get_exif_time(file: &File) -> Result<Option<NaiveDateTime>> {
-    let mut bufreader = std::io::BufReader::new(file);
-    let exifreader = exif::Reader::new();
-    let exif = exifreader.read_from_container(&mut bufreader)?;
-    let datetime = exif.get_field(exif::Tag::DateTime, exif::In::PRIMARY);
+use crate::analysis::filename2date::FileNameToDateTransformer;
 
-    Ok(datetime
-        .map(|field| {
-            let datetime = field.display_value().to_string();
-            NaiveDateTime::parse_from_str(&datetime, "%Y-%m-%d %H:%M:%S")
-        })
-        .transpose()?)
-}
-
-#[cfg(feature = "video")]
-static FFMPEG_INITIALIZED: Mutex<bool> = Mutex::new(false);
-#[cfg(feature = "video")]
-fn init_ffmpeg() -> Result<()> {
-    match FFMPEG_INITIALIZED.lock() {
-        Ok(mut guard) => {
-            if *guard {
-                return Ok(());
-            }
-            ffmpeg::init().map_err(|e| anyhow!("Error initializing ffmpeg: {:?}", e))?;
-            *guard = true;
-            Ok(())
-        }
-        Err(poisoned) => {
-            return Err(anyhow!("Mutex poisoned: {:?}", poisoned));
-        }
-    }
-}
-
-#[cfg(feature = "video")]
-/// This function retrieves the date and time from the video metadata.
-/// The function uses the `ffmpeg` crate to read the metadata from the video file.
-///
-/// # Arguments
-/// * `path` - A reference to a `Path` object.
-///
-/// # Returns
-/// * `Some(NaiveDateTime)` - If the date and time could be retrieved from the video metadata.
-/// * `None` - If there is no date and time in the video metadata.
-///
-/// # Errors
-/// This function will return an error if:
-/// * The video file could not be read.
-pub fn get_video_time<P: AsRef<Path> + ?Sized>(path: &P) -> Result<Option<NaiveDateTime>> {
-    init_ffmpeg()?;
-
-    let instance = ffmpeg::format::input(&path)?;
-
-    let result = instance
-        .metadata()
-        .get("creation_time")
-        .map(|v| NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S%Z"));
-
-    Ok(result.transpose()?)
-}
-
-/// `NameTransformer` is a struct that represents a transformer to convert a file name into a `NaiveDateTime`.
-///
-/// It contains a regular expression to match the name and a transformation function to convert the matched part into a `NaiveDateTime`.
-///
-/// # Fields
-///
-/// * `regex` - A `regex::Regex` that represents the regular expression to match the name.
-/// * `transform` - A function that takes a `regex::Captures` and returns a `Result<NaiveDateTime>`. This function is used to convert the matched phrase into a `NaiveDateTime`.
-pub struct NameTransformer {
-    regex: regex::Regex,
-    transform: fn(regex::Captures) -> Result<NaiveDateTime>,
-}
-
-impl NameTransformer {
-    /// Constructs a new `NameTransformer` instance.
-    ///
-    /// # Arguments
-    ///
-    /// * `regex` - A `regex::Regex` that represents the regular expression to match the name.
-    /// * `transform` - A function that takes a `regex::Captures` and returns a `Result<NaiveDateTime>`. This function is used to convert the matched phrase into a `NaiveDateTime`.
-    ///
-    /// # Returns
-    ///
-    /// * `NameTransformer` - A new `NameTransformer` instance.
-    pub fn new(
-        regex: regex::Regex,
-        transform: fn(regex::Captures) -> Result<NaiveDateTime>,
-    ) -> NameTransformer {
-        NameTransformer { regex, transform }
-    }
-
-    /// This function generates a vector of `NameTransformer` instances.
-    ///
-    /// Each `NameTransformer` instance contains a regular expression and a transformation function.
-    /// The regular expression is used to match a specific pattern in a file name.
-    /// The transformation function is used to convert the matched string into a `NaiveDateTime`.
-    /// The result will contain a standard list of `NameTransformer` instances that can be used to parse file names.
-    ///
-    /// # Returns
-    ///
-    /// * `Result<Vec<NameTransformer>>` - A `Result` that, if `Ok`, contains a vector of `NameTransformer` instances.
-    ///   If an error occurred during the process, the `Result` will be `Err`.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if:
-    ///
-    /// * The regular expression could not be compiled.
-    pub fn get_standard_name_parsers() -> Result<Vec<NameTransformer>> {
-        let p = NameTransformer {
-            regex: regex::Regex::new(
-                r"(\d{4})[-_]?(\d{2})[-_]?(\d{2})(\D+(\d{2})[-_:]?(\d{2})[-_:]?(\d{2}))?[-_]?",
-            )?,
-
-            transform: |m| {
-                let year = m
-                    .get(1)
-                    .ok_or_else(|| anyhow!("Regex did not find year group"))?
-                    .as_str()
-                    .parse::<i32>()?;
-                let month = m
-                    .get(2)
-                    .ok_or_else(|| anyhow!("Regex did not find month group"))?
-                    .as_str()
-                    .parse::<u32>()?;
-                let day = m
-                    .get(3)
-                    .ok_or_else(|| anyhow!("Regex did not find day group"))?
-                    .as_str()
-                    .parse::<u32>()?;
-
-                let time = if let (Some(hour), Some(minute), Some(second)) =
-                    (m.get(5), m.get(6), m.get(7))
-                {
-                    NaiveTime::from_hms_opt(
-                        hour.as_str().parse::<u32>()?,
-                        minute.as_str().parse::<u32>()?,
-                        second.as_str().parse::<u32>()?,
-                    )
-                    .ok_or_else(|| anyhow!("Invalid time"))?
-                } else {
-                    NaiveTime::MIN
-                };
-
-                let date = NaiveDate::from_ymd_opt(year, month, day)
-                    .ok_or_else(|| anyhow!("Invalid date"))?;
-                Ok(NaiveDateTime::new(date, time))
-            },
-        };
-
-        Ok(vec![p])
-    }
-}
-
-/// This function tries to retrieve a photo creation date and time from a file name.
+/// This function tries to retrieve a file creation date and time from a file name.
 ///
 /// The function accepts a list of `NameTransformer` instances that are used to match and transform the file name into a datetime.
 /// Each `NameTransformer` instance contains a regular expression and a transformation function.
@@ -210,17 +34,16 @@ impl NameTransformer {
 /// * A transformation function failed and errors
 pub fn get_name_time(
     name: &str,
-    parsers: &Vec<NameTransformer>,
+    parsers: &Vec<Box<dyn FileNameToDateTransformer>>,
 ) -> Result<Option<(NaiveDateTime, String)>> {
-    for phrase in parsers {
-        let iter = phrase.regex.captures_iter(name);
-        for cap in iter {
-            let matched = cap.get(0).map_or("", |m| m.as_str());
-            match (phrase.transform)(cap) {
-                Ok(dt) => return Ok(Some((dt, name.replace(matched, "")))),
-                Err(e) => {
-                    log::error!("Error: {:?}", e);
-                }
+    for transformer in parsers {
+        let result = transformer.try_transform_name(name);
+        match result {
+            Ok(Some((dt, name))) => return Ok(Some((dt, name))),
+            Ok(None) => continue,
+            Err(e) => {
+                log::error!("Error: {:?}", e);
+                continue;
             }
         }
     }

--- a/src/analysis/exif2date.rs
+++ b/src/analysis/exif2date.rs
@@ -1,0 +1,35 @@
+use chrono::NaiveDateTime;
+use std::fs::File;
+
+/// This function retrieves the date and time from the EXIF data of a file.
+///
+/// # Arguments
+///
+/// * `file` - A reference to a `File` object.
+///
+/// # Returns
+///
+/// * `Result<Option<NaiveDateTime>>` - A `Result` that, if `Ok`, contains an `Option` with the date and time from the EXIF data.
+///   If the date and time could not be retrieved, the `Option` will be `None`.
+///   If an error occurred during the process, the `Result` will be `Err`.
+///
+/// # Errors
+///
+/// This function will return an error if:
+///
+/// * The file could not be read.
+/// * The EXIF data could not be read from the file.
+/// * The date and time could not be parsed from the EXIF data.
+pub fn get_exif_time(file: &File) -> anyhow::Result<Option<NaiveDateTime>> {
+    let mut bufreader = std::io::BufReader::new(file);
+    let exifreader = exif::Reader::new();
+    let exif = exifreader.read_from_container(&mut bufreader)?;
+    let datetime = exif.get_field(exif::Tag::DateTime, exif::In::PRIMARY);
+
+    Ok(datetime
+        .map(|field| {
+            let datetime = field.display_value().to_string();
+            NaiveDateTime::parse_from_str(&datetime, "%Y-%m-%d %H:%M:%S")
+        })
+        .transpose()?)
+}

--- a/src/analysis/filename2date.rs
+++ b/src/analysis/filename2date.rs
@@ -1,0 +1,100 @@
+use anyhow::anyhow;
+use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
+use lazy_static::lazy_static;
+use regex::{Captures, Regex};
+
+lazy_static! {
+    static ref RE_NAIVE_FILENAME: Regex = regex::Regex::new(
+        r"(\d{4})[-_]?(\d{2})[-_]?(\d{2})(\D+(\d{2})[-_:]?(\d{2})[-_:]?(\d{2}))?[-_]?",
+    )
+    .expect("Failed to compile regex");
+}
+
+#[derive(Debug, Default)]
+/// A `FileNameToDateTransformer` implementation that extracts the date from a file name in the format
+/// `YYYY[-_]?MM\[-_]?DD\[-_]?(HH[-_:]?MM[-_:]?SS)?`.
+pub struct NaiveFileNameParser {}
+
+impl FileNameToDateTransformer for NaiveFileNameParser {
+    fn get_regex(&self) -> &Regex {
+        &RE_NAIVE_FILENAME
+    }
+
+    fn transform(&self, capture: &Captures) -> anyhow::Result<Option<NaiveDateTime>> {
+        let year = capture
+            .get(1)
+            .ok_or_else(|| anyhow!("Regex did not find year group"))?
+            .as_str()
+            .parse::<i32>()?;
+        let month = capture
+            .get(2)
+            .ok_or_else(|| anyhow!("Regex did not find month group"))?
+            .as_str()
+            .parse::<u32>()?;
+        let day = capture
+            .get(3)
+            .ok_or_else(|| anyhow!("Regex did not find day group"))?
+            .as_str()
+            .parse::<u32>()?;
+
+        let time = if let (Some(hour), Some(minute), Some(second)) =
+            (capture.get(5), capture.get(6), capture.get(7))
+        {
+            NaiveTime::from_hms_opt(
+                hour.as_str().parse::<u32>()?,
+                minute.as_str().parse::<u32>()?,
+                second.as_str().parse::<u32>()?,
+            )
+            .ok_or_else(|| anyhow!("Invalid time"))?
+        } else {
+            // no time given, assume 00:00
+            NaiveTime::MIN
+        };
+
+        let date =
+            NaiveDate::from_ymd_opt(year, month, day).ok_or_else(|| anyhow!("Invalid date"))?;
+        Ok(Some(NaiveDateTime::new(date, time)))
+    }
+}
+
+/// `NameTransformer` is a struct that represents a transformer to convert a file name into a `NaiveDateTime`.
+///
+/// This is done in two steps:
+/// 1. A regular expression is matched against the file name.
+/// 2. If the regular expression matches: Call the transformer function
+pub trait FileNameToDateTransformer {
+    /// Gets the regular expression to match against the file name.
+    ///
+    /// # Returns
+    /// A reference to the regular expression.
+    fn get_regex(&self) -> &regex::Regex;
+
+    /// This function is called if the regular expression matches the file name.
+    ///
+    /// # Arguments
+    /// * `capture` - A reference to a `regex::Captures` object that contains the matched groups.
+    ///
+    /// # Returns
+    /// * `NaiveDateTime` - If the date and time could be extracted from the matched groups.
+    /// * `None` - If the transformer decides that it cant extract a date but no error occurred. The next transformer will be called.
+    ///
+    /// # Errors
+    /// If transformation fails, an error is returned. The program will log the error and try the next transformer.
+    fn transform(&self, capture: &regex::Captures) -> anyhow::Result<Option<NaiveDateTime>>;
+
+    fn try_transform_name(&self, name: &str) -> anyhow::Result<Option<(NaiveDateTime, String)>> {
+        let all_matches = self.get_regex().captures_iter(name);
+        for current_match in all_matches {
+            let matched = current_match.get(0).map_or("", |m| m.as_str());
+            match self.transform(&current_match) {
+                Ok(Some(dt)) => return Ok(Some((dt, name.replace(matched, "")))),
+                Ok(None) => continue,
+                Err(e) => {
+                    log::error!("Error: {:?}", e);
+                    continue;
+                }
+            }
+        }
+        Ok(None) // No match found
+    }
+}

--- a/src/analysis/name_formatters.rs
+++ b/src/analysis/name_formatters.rs
@@ -1,0 +1,38 @@
+use anyhow::Result;
+use chrono::NaiveDateTime;
+use regex::Regex;
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum FileType {
+    Image,
+    Video,
+    None,
+}
+
+#[derive(Debug)]
+pub struct NameFormatterInvocationInfo<'a> {
+    pub date: &'a Option<NaiveDateTime>,
+    pub date_string: &'a str,
+    pub date_default_format: &'a str,
+    pub file_type: &'a FileType,
+    pub cleaned_name: &'a str,
+    pub duplicate_counter: Option<u32>,
+}
+
+pub trait NameFormatter {
+    fn argument_template(&self) -> &Regex;
+    fn replacement_text(
+        &self,
+        matched: regex::Captures,
+        invocation_info: &NameFormatterInvocationInfo,
+    ) -> Result<String>;
+}
+
+mod date;
+pub use date::*;
+mod name;
+pub use name::*;
+mod duplicate;
+pub use duplicate::*;
+mod file_type;
+pub use file_type::*;

--- a/src/analysis/name_formatters/date.rs
+++ b/src/analysis/name_formatters/date.rs
@@ -1,0 +1,31 @@
+use crate::analysis::name_formatters::{NameFormatter, NameFormatterInvocationInfo};
+use anyhow::Result;
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref DATE_FORMAT: regex::Regex =
+        regex::Regex::new(r"^(date|d)(\?(.+))?$").expect("Failed to compile regex");
+}
+
+/// Formats a date format command {date} to a date string.
+#[derive(Debug, Default)]
+pub struct FormatDate {}
+
+impl NameFormatter for FormatDate {
+    fn argument_template(&self) -> &Regex {
+        &DATE_FORMAT
+    }
+    fn replacement_text(
+        &self,
+        capture: regex::Captures<'_>,
+        invocation_info: &NameFormatterInvocationInfo,
+    ) -> Result<String> {
+        let format_string = capture
+            .get(3)
+            .map_or(invocation_info.date_default_format, |m| m.as_str());
+        Ok(invocation_info.date.map_or("NODATE".to_string(), |x| {
+            x.format(format_string).to_string()
+        }))
+    }
+}

--- a/src/analysis/name_formatters/duplicate.rs
+++ b/src/analysis/name_formatters/duplicate.rs
@@ -1,0 +1,29 @@
+use crate::analysis::name_formatters::{NameFormatter, NameFormatterInvocationInfo};
+use anyhow::Result;
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref DUPLICATE_FORMAT: regex::Regex =
+        regex::Regex::new(r"^(dup|duplicate)$").expect("Failed to compile regex");
+}
+
+/// Formats a duplicate format command {dup} to a duplicate counter string.
+#[derive(Debug, Default)]
+pub struct FormatDuplicate {}
+
+impl NameFormatter for FormatDuplicate {
+    fn argument_template(&self) -> &Regex {
+        &DUPLICATE_FORMAT
+    }
+    fn replacement_text(
+        &self,
+        _capture: regex::Captures<'_>,
+        invocation_info: &NameFormatterInvocationInfo,
+    ) -> Result<String> {
+        let duplicate_string = invocation_info
+            .duplicate_counter
+            .map_or("".to_string(), |c| c.to_string());
+        Ok(duplicate_string)
+    }
+}

--- a/src/analysis/name_formatters/file_type.rs
+++ b/src/analysis/name_formatters/file_type.rs
@@ -1,0 +1,36 @@
+use crate::analysis::name_formatters::{FileType, NameFormatter, NameFormatterInvocationInfo};
+use anyhow::Result;
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref FILE_TYPE_FORMAT: regex::Regex =
+        regex::Regex::new(r"^(ftype|type|t)(\?(([^,\n]*)(,([^,\n]*))?))?$")
+            .expect("Failed to compile regex");
+}
+
+/// Formats a file type format command {ftype} to a file type string.
+#[derive(Debug, Default)]
+pub struct FormatFileType {}
+
+impl NameFormatter for FormatFileType {
+    fn argument_template(&self) -> &Regex {
+        &FILE_TYPE_FORMAT
+    }
+    fn replacement_text(
+        &self,
+        capture: regex::Captures<'_>,
+        invocation_info: &NameFormatterInvocationInfo,
+    ) -> Result<String> {
+        let regex_image_name = capture.get(4).map(|m| m.as_str());
+        let regex_video_name = capture.get(6).map(|m| m.as_str());
+
+        let file_type = match invocation_info.file_type {
+            FileType::Image => regex_image_name.unwrap_or("IMG"),
+            FileType::Video => regex_video_name.unwrap_or("MOV"),
+            FileType::None => "",
+        };
+
+        Ok(file_type.to_string())
+    }
+}

--- a/src/analysis/name_formatters/name.rs
+++ b/src/analysis/name_formatters/name.rs
@@ -1,0 +1,26 @@
+use crate::analysis::name_formatters::{NameFormatter, NameFormatterInvocationInfo};
+use anyhow::Result;
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref NAME_FORMAT: regex::Regex =
+        regex::Regex::new(r"^(name|n)$").expect("Failed to compile regex");
+}
+
+/// Formats a name format command {name} to a name string.
+#[derive(Debug, Default)]
+pub struct FormatName {}
+
+impl NameFormatter for FormatName {
+    fn argument_template(&self) -> &Regex {
+        &NAME_FORMAT
+    }
+    fn replacement_text(
+        &self,
+        _capture: regex::Captures<'_>,
+        invocation_info: &NameFormatterInvocationInfo,
+    ) -> Result<String> {
+        Ok(invocation_info.cleaned_name.to_string())
+    }
+}

--- a/src/analysis/video2date.rs
+++ b/src/analysis/video2date.rs
@@ -1,0 +1,47 @@
+use anyhow::anyhow;
+use chrono::NaiveDateTime;
+use ffmpeg_next as ffmpeg;
+use std::path::Path;
+use std::sync::Mutex;
+
+static FFMPEG_INITIALIZED: Mutex<bool> = Mutex::new(false);
+
+fn init_ffmpeg() -> anyhow::Result<()> {
+    match FFMPEG_INITIALIZED.lock() {
+        Ok(mut guard) => {
+            if *guard {
+                return Ok(());
+            }
+            ffmpeg::init().map_err(|e| anyhow!("Error initializing ffmpeg: {:?}", e))?;
+            *guard = true;
+            Ok(())
+        }
+        Err(poisoned) => Err(anyhow!("Mutex poisoned: {:?}", poisoned)),
+    }
+}
+
+/// This function retrieves the date and time from the video metadata.
+/// The function uses the `ffmpeg` crate to read the metadata from the video file.
+///
+/// # Arguments
+/// * `path` - A reference to a `Path` object.
+///
+/// # Returns
+/// * `Some(NaiveDateTime)` - If the date and time could be retrieved from the video metadata.
+/// * `None` - If there is no date and time in the video metadata.
+///
+/// # Errors
+/// This function will return an error if:
+/// * The video file could not be read.
+pub fn get_video_time<P: AsRef<Path> + ?Sized>(path: &P) -> anyhow::Result<Option<NaiveDateTime>> {
+    init_ffmpeg()?;
+
+    let instance = ffmpeg::format::input(&path)?;
+
+    let result = instance
+        .metadata()
+        .get("creation_time")
+        .map(|v| NaiveDateTime::parse_from_str(v, "%Y-%m-%dT%H:%M:%S%Z"));
+
+    Ok(result.transpose()?)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ struct Arguments {
     /// The action mode, possible values are move, copy, hardlink, relative_symlink, absolute_symlink.
     /// Move will move the files, Copy will copy the files, Hardlink (alias: hard) will create hardlinks, RelativeSymlink (alias: relsym) will create relative symlinks, AbsoluteSymlink (alias: abssym) will create absolute symlinks.
     #[arg(short, long, default_value = "move")]
-    move_mode: action::ActionMode,
+    move_mode: action::ActualAction,
     /// Dry-run
     /// If set, the tool will not move any files but only print the actions it would take.
     #[arg(short = 'n', long, default_value = "false")]
@@ -85,9 +85,9 @@ fn main() {
         date_format: args.date_format.clone(),
         extensions: args.extensions.clone(),
         action_type: if args.dry_run {
-            action::ActionMode::DryRun
+            action::ActionMode::DryRun(args.move_mode)
         } else {
-            args.move_mode
+            action::ActionMode::Execute(args.move_mode)
         },
         #[cfg(feature = "video")]
         video_extensions: args.video_extensions.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,18 +22,23 @@ struct Arguments {
     /// See [https://docs.rs/chrono/latest/chrono/format/strftime/index.html] for more information.
     #[arg(long, default_value = "%Y%m%d-%H%M%S")]
     date_format: String,
-    /// The target file format. Everything outside a {...} block is copied as is.
-    /// {name} / {n} is replaced with a filename without the date part.
-    /// {dup} is replaced with a number if a file with the target name already exists.
-    /// {date} / {d} is replaced with the date string, formatted according to the date_format parameter.
-    /// {date?<format>} is replaced with the date string, formatted according to the <format> parameter. See [https://docs.rs/chrono/latest/chrono/format/strftime/index.html] for more information.
-    /// {type} / {t} is replaced with MOV or IMG.
-    /// {type?<img>,<vid>} is replaced with <img> if the file is an image, <vid> if the file is a video. Note that, when using other types than IMG or MOV,
+    /// The target file format. Everything outside a {...} block is copied as is. The target file format may contain "/" to
+    /// indicate that the file should be placed in a subdirectory. Use the `--mkdir` flag to create the subdirectories.
+    /// `{name}` is replaced with a filename without the date part.
+    /// `{dup}` is replaced with a number if a file with the target name already exists.
+    /// `{date}` is replaced with the date string, formatted according to the date_format parameter.
+    /// `{date?format}` is replaced with the date string, formatted according to the "format" parameter. See [https://docs.rs/chrono/latest/chrono/format/strftime/index.html] for more information.
+    /// `{type}` is replaced with MOV or IMG.
+    /// `{type?img,vid}` is replaced with `img` if the file is an image, `vid` if the file is a video. Note that, when using other types than IMG or MOV,
     /// and rerunning the program again, the custom type will be seen as part of the file name.
     /// Commands of the form {label:cmd} are replaced by {cmd}; if the replacement string is not empty then a prefix of "label" is added.
     /// This might be useful to add separators only if there is e.g. a {dup} part.
     #[arg(short, long, default_value = "{type}{_:date}{-:name}{-:dup}")]
     file_format: String,
+    /// If the file format contains a "/", indicating that the file should be placed in a subdirectory,
+    /// the mkdir flag controls if the tool is allowed to create non-existing subdirectories. No folder is created in dry-run mode.
+    #[arg(long, default_value = "false", alias = "mkdirs")]
+    mkdir: bool,
     /// A comma separated list of file extensions to include in the analysis.
     #[arg(short, long, default_value = "jpg,jpeg,png,tiff,heif,heic,avif,webp", value_delimiter = ',', num_args = 0..)]
     extensions: Vec<String>,
@@ -87,6 +92,7 @@ fn main() {
         file_format: args.file_format.clone(),
         date_format: args.date_format.clone(),
         extensions: args.extensions.clone(),
+        mkdir: args.mkdir,
         action_type: if args.dry_run {
             action::ActionMode::DryRun(args.move_mode)
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,9 @@ use std::path::PathBuf;
 
 /// A simple command line tool to sort photos by date.
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(version, about, long_about = "A tool to rename and sort photos/videos by its EXIF date/metadata. It tries to extract the date
+from the EXIF data or file name and renames the image file according to a given
+format string.")]
 struct Arguments {
     /// The source directory to read the photos from.
     #[arg(short, long, num_args = 1.., required = true)]


### PR DESCRIPTION
Introducing the possibility to specify a target format string that contains sub folders.
This e.g. allows sorting a photo library to folders like `YEAR/photo-XYZ.png`

Also overhauled the target format string system. See `README.md` or `--help`

See #33 