### PR TITLE
feat: extension can be made upper or lower case when specifying a custom name format with `{ext}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ photo_sort \
   --target-dir /path/to/sorted_photos \
   --analysis-mode "exif_then_name" \
   --date-format "%Y-%m-%d-_%H%M%S" \
-  --file-format "{date?%Y}/{date}{_:dup}" \
+  --file-format "{date?%Y}/{date}{_:dup}.{ext}" \
   --mkdir \
   --extensions "png,jpg" \
   --move-mode "hardlink"
@@ -93,7 +93,10 @@ Options:
                                        information. `{type}` is replaced with MOV or IMG. `{type?img,vid}` is replaced
                                        with `img` if the file is an image, `vid` if the file is a video. Note that, when
                                        using other types than IMG or MOV, and rerunning the program again, the custom
-                                       type will be seen as part of the file name. Commands of the form {label:cmd} are
+                                       type will be seen as part of the file name. `{ext?upper/lower/copy}` is replaced
+                                       with the original file extension. If `?upper` or `?lower` is specified, the
+                                       extension will be made lower/upper case. leaving out `?...` or using `copy` copies
+                                       the original file extension. Commands of the form {label:cmd} are
                                        replaced by {cmd}; if the replacement string is not empty then a prefix of "label"
                                        is added. This might be useful to add separators only if there is e.g. a {dup}
                                        part [default: {type}{_:date}{-:name}{-:dup}]

--- a/src/analysis/name_formatters.rs
+++ b/src/analysis/name_formatters.rs
@@ -17,6 +17,7 @@ pub struct NameFormatterInvocationInfo<'a> {
     pub file_type: &'a FileType,
     pub cleaned_name: &'a str,
     pub duplicate_counter: Option<u32>,
+    pub extension: String,
 }
 
 pub trait NameFormatter {
@@ -36,3 +37,5 @@ mod duplicate;
 pub use duplicate::*;
 mod file_type;
 pub use file_type::*;
+mod extension;
+pub use extension::*;

--- a/src/analysis/name_formatters/extension.rs
+++ b/src/analysis/name_formatters/extension.rs
@@ -21,17 +21,15 @@ impl NameFormatter for FormatExtension {
         capture: regex::Captures<'_>,
         invocation_info: &NameFormatterInvocationInfo,
     ) -> Result<String> {
-        let option = capture
-            .get(3)
-            .map_or("copy", |m| m.as_str());
-        
+        let option = capture.get(3).map_or("copy", |m| m.as_str());
+
         let extension = match option {
-            "lower"|"low"|"lowercase"|"l" => invocation_info.extension.to_lowercase(),
-            "upper"|"up"|"uppercase"|"u" => invocation_info.extension.to_uppercase(),
-            "copy"|"normal"|"standard"|"pass"|"p" => invocation_info.extension.to_owned(),
+            "lower" | "low" | "lowercase" | "l" => invocation_info.extension.to_lowercase(),
+            "upper" | "up" | "uppercase" | "u" => invocation_info.extension.to_uppercase(),
+            "copy" | "normal" | "standard" | "pass" | "p" => invocation_info.extension.to_owned(),
             _ => return Err(anyhow!("Unknown extension format")),
         };
-        
+
         Ok(extension)
     }
 }

--- a/src/analysis/name_formatters/extension.rs
+++ b/src/analysis/name_formatters/extension.rs
@@ -1,0 +1,37 @@
+use crate::analysis::name_formatters::{NameFormatter, NameFormatterInvocationInfo};
+use anyhow::{anyhow, Result};
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref DATE_FORMAT: regex::Regex =
+        regex::Regex::new(r"^(ext|extension)(\?(.+))?$").expect("Failed to compile regex");
+}
+
+/// Formats a date format command {date} to a date string.
+#[derive(Debug, Default)]
+pub struct FormatExtension {}
+
+impl NameFormatter for FormatExtension {
+    fn argument_template(&self) -> &Regex {
+        &DATE_FORMAT
+    }
+    fn replacement_text(
+        &self,
+        capture: regex::Captures<'_>,
+        invocation_info: &NameFormatterInvocationInfo,
+    ) -> Result<String> {
+        let option = capture
+            .get(3)
+            .map_or("copy", |m| m.as_str());
+        
+        let extension = match option {
+            "lower"|"low"|"lowercase"|"l" => invocation_info.extension.to_lowercase(),
+            "upper"|"up"|"uppercase"|"u" => invocation_info.extension.to_uppercase(),
+            "copy"|"normal"|"standard"|"pass"|"p" => invocation_info.extension.to_owned(),
+            _ => return Err(anyhow!("Unknown extension format")),
+        };
+        
+        Ok(extension)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,6 +461,7 @@ impl Analyzer {
             file_type: &ftype,
             cleaned_name: &cleaned_name,
             duplicate_counter: None,
+            extension: path.extension().map(|ext| ext.to_string_lossy().to_string()).unwrap_or("unknown".to_owned()),
         };
 
         let new_file_path = |file_name_info: &NameFormatterInvocationInfo| -> Result<PathBuf> {
@@ -484,7 +485,7 @@ impl Analyzer {
                     target_path.push(component);
                 }
             }
-            Ok(target_path.with_extension(path.extension().expect("There should be an extension")))
+            Ok(target_path)
         };
 
         let mut new_path = new_file_path(&file_name_info)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -461,7 +461,10 @@ impl Analyzer {
             file_type: &ftype,
             cleaned_name: &cleaned_name,
             duplicate_counter: None,
-            extension: path.extension().map(|ext| ext.to_string_lossy().to_string()).unwrap_or("unknown".to_owned()),
+            extension: path
+                .extension()
+                .map(|ext| ext.to_string_lossy().to_string())
+                .unwrap_or("unknown".to_owned()),
         };
 
         let new_file_path = |file_name_info: &NameFormatterInvocationInfo| -> Result<PathBuf> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,7 @@ impl Analyzer {
             Literal(String),
             Command(&'a str, String),
         }
-        impl<'a> FormatString<'a> {
+        impl FormatString<'_> {
             fn formatted_string(self) -> String {
                 match self {
                     FormatString::Literal(str) => str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,9 +37,11 @@ struct Arguments {
     /// `{type}` is replaced with MOV or IMG.
     /// `{type?img,vid}` is replaced with `img` if the file is an image, `vid` if the file is a video. Note that, when using other types than IMG or MOV,
     /// and rerunning the program again, the custom type will be seen as part of the file name.
+    /// `{ext?upper/lower/copy}` is replaced with the original file extension. If `?upper` or `?lower` is specified, the extension will be made lower/upper case.
+    ///      leaving out `?...` or using `copy` copies the original file extension.
     /// Commands of the form {label:cmd} are replaced by {cmd}; if the replacement string is not empty then a prefix of "label" is added.
     /// This might be useful to add separators only if there is e.g. a {dup} part.
-    #[arg(short, long, default_value = "{type}{_:date}{-:name}{-:dup}")]
+    #[arg(short, long, default_value = "{type}{_:date}{-:name}{-:dup}.{ext}")]
     file_format: String,
     /// If the file format contains a "/", indicating that the file should be placed in a subdirectory,
     /// the mkdir flag controls if the tool is allowed to create non-existing subdirectories. No folder is created in dry-run mode.
@@ -126,6 +128,7 @@ fn main() {
     analyzer.add_formatter(photo_sort::analysis::name_formatters::FormatDuplicate::default());
     analyzer.add_formatter(photo_sort::analysis::name_formatters::FormatDate::default());
     analyzer.add_formatter(photo_sort::analysis::name_formatters::FormatFileType::default());
+    analyzer.add_formatter(photo_sort::analysis::name_formatters::FormatExtension::default());
 
     debug!("Running program");
 


### PR DESCRIPTION
See #49 