### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/0xCCF4/PhotoSort/compare/v0.2.1...v0.2.2) - 2024-10-20
+
+### Added
+
+- added option to specify file format for unknown files (which are not images/videos)
+- a different format string for files with no derived date
+- output warning if no date was derived for a file
+
 ## [0.2.1](https://github.com/0xCCF4/PhotoSort/compare/v0.2.0...v0.2.1) - 2024-10-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "photo_sort"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "photo_sort"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = """
 A tool to rename and sort photos/videos by its EXIF date/metadata. It tries to extract the date


### PR DESCRIPTION
## 🤖 New release
* `photo_sort`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/0xCCF4/PhotoSort/compare/v0.2.1...v0.2.2) - 2024-10-20

### Added

- added option to specify file format for unknown files (which are not images/videos)
- a different format string for files with no derived date
- output warning if no date was derived for a file
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).