### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/0xCCF4/PhotoSort/compare/v0.2.3...v0.2.4) - 2024-10-29
+
+### Added
+
+- added multithreading support
+
+### Other
+
+- Merge pull request [#59](https://github.com/0xCCF4/PhotoSort/pull/59) from 0xCCF4/dependabot/cargo/regex-1.11.1
+- *(deps)* bump regex from 1.11.0 to 1.11.1
+
 ## [0.2.3](https://github.com/0xCCF4/PhotoSort/compare/v0.2.2...v0.2.3) - 2024-10-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "photo_sort"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "photo_sort"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 description = """
 A tool to rename and sort photos/videos by its EXIF date/metadata. It tries to extract the date


### PR DESCRIPTION
## 🤖 New release
* `photo_sort`: 0.2.3 -> 0.2.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.4](https://github.com/0xCCF4/PhotoSort/compare/v0.2.3...v0.2.4) - 2024-10-29

### Added

- added multithreading support

### Other

- Merge pull request [#59](https://github.com/0xCCF4/PhotoSort/pull/59) from 0xCCF4/dependabot/cargo/regex-1.11.1
- *(deps)* bump regex from 1.11.0 to 1.11.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).