### PR TITLE
chore: release v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.8](https://github.com/0xCCF4/PhotoSort/compare/v0.2.7...v0.2.8) - 2025-09-15
+
+### Added
+
+- expose cmd argument to choose which EXIF date to use
+
 ## [0.2.7](https://github.com/0xCCF4/PhotoSort/compare/v0.2.6...v0.2.7) - 2025-09-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "photo_sort"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "photo_sort"
-version = "0.2.7"
+version = "0.2.8"
 edition = "2021"
 description = """
 A tool to rename and sort photos/videos by its EXIF date/metadata. It tries to extract the date


### PR DESCRIPTION



## 🤖 New release

* `photo_sort`: 0.2.7 -> 0.2.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.8](https://github.com/0xCCF4/PhotoSort/compare/v0.2.7...v0.2.8) - 2025-09-15

### Added

- expose cmd argument to choose which EXIF date to use
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).