### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/0xCCF4/PhotoSort/compare/v0.2.12...v0.3.0) - 2026-04-12
+
+### Fixed
+
+- typo in cmdline args
+
+### Other
+
+- [**breaking**] add file include and exclude flags via regex and normal string
+- exclude arguments and help comment to main_impl
+
 ## [0.2.12](https://github.com/0xCCF4/PhotoSort/compare/v0.2.11...v0.2.12) - 2026-04-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "photo_sort"
-version = "0.2.12"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "photo_sort"
-version = "0.2.12"
+version = "0.3.0"
 edition = "2021"
 description = """
 A tool to rename and sort photos/videos by its EXIF date/metadata. It tries to extract the date


### PR DESCRIPTION



## 🤖 New release

* `photo_sort`: 0.2.12 -> 0.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/0xCCF4/PhotoSort/compare/v0.2.12...v0.3.0) - 2026-04-12

### Fixed

- typo in cmdline args

### Other

- [**breaking**] add file include and exclude flags via regex and normal string
- exclude arguments and help comment to main_impl
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).