### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/0xCCF4/PhotoSort/compare/v0.3.1...v0.3.2) - 2026-04-19
+
+### Fixed
+
+- *(ci)* dependency issue, using newer cargo version on nix branch 24.11
+
+### Other
+
+- *(fix)* fix clippy warnings
+- --bracket-fmt option and measures for circumventing race condition on file naming
+
 ## [0.3.1](https://github.com/0xCCF4/PhotoSort/compare/v0.3.0...v0.3.1) - 2026-04-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,7 +493,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "photo_sort"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "photo_sort"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = """
 A tool to rename and sort photos/videos by its EXIF date/metadata. It tries to extract the date


### PR DESCRIPTION



## 🤖 New release

* `photo_sort`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/0xCCF4/PhotoSort/compare/v0.3.1...v0.3.2) - 2026-04-19

### Fixed

- *(ci)* dependency issue, using newer cargo version on nix branch 24.11

### Other

- *(fix)* fix clippy warnings
- --bracket-fmt option and measures for circumventing race condition on file naming
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).