### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/0xCCF4/PhotoSort/compare/v0.3.4...v0.3.5) - 2026-06-20
+
+### Other
+
+- *(deps)* bump regex from 1.12.3 to 1.12.4 ([#203](https://github.com/0xCCF4/PhotoSort/pull/203))
+- Stabilize video-feature CI install step on ubuntu-latest ([#204](https://github.com/0xCCF4/PhotoSort/pull/204))
+- Merge pull request #202 from 0xCCF4/dependabot/cargo/log-0.4.32
+- *(deps)* bump log from 0.4.31 to 0.4.32
+- *(deps)* bump log from 0.4.30 to 0.4.31
+- *(deps)* bump log from 0.4.29 to 0.4.30
+
 ## [0.3.4](https://github.com/0xCCF4/PhotoSort/compare/v0.3.3...v0.3.4) - 2026-05-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "photo_sort"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "photo_sort"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 description = """
 A tool to rename and sort photos/videos by its EXIF date/metadata. It tries to extract the date


### PR DESCRIPTION



## 🤖 New release

* `photo_sort`: 0.3.4 -> 0.3.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.5](https://github.com/0xCCF4/PhotoSort/compare/v0.3.4...v0.3.5) - 2026-06-20

### Other

- *(deps)* bump regex from 1.12.3 to 1.12.4 ([#203](https://github.com/0xCCF4/PhotoSort/pull/203))
- Stabilize video-feature CI install step on ubuntu-latest ([#204](https://github.com/0xCCF4/PhotoSort/pull/204))
- Merge pull request #202 from 0xCCF4/dependabot/cargo/log-0.4.32
- *(deps)* bump log from 0.4.31 to 0.4.32
- *(deps)* bump log from 0.4.30 to 0.4.31
- *(deps)* bump log from 0.4.29 to 0.4.30
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).